### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,47 @@
 CC = gcc
-CFLAGS = -g
+CFLAGS = -g -pthread
 
 .PHONY: clean setup
 
 all: server client hash_test conflicting_writes setup
 
 server: network.o server.o runner.o hash.o
-	gcc -g -lpthread -o server network.o server.o runner.o hash.o
+	$(CC) $(CFLAGS) -o server network.o server.o runner.o hash.o
 
 client: client.o network.o
+	$(CC) $(CFLAGS) -o client client.o network.o
 
 hash_test: hash.o hash_test.o
+	$(CC) $(CFLAGS) -o hash_test hash_test.o hash.o
 
 conflicting_writes: conflicting_writes.o network.o
+	$(CC) $(CFLAGS) -o conflicting_writes conflicting_writes.o network.o
 
 network.o: network.c network.h constants.h
+	$(CC) $(CFLAGS) -c -o network.o network.c
 
 server.o: server.c network.h server.h rpc.c jobs.c failure.c constants.h
+	$(CC) $(CFLAGS) -c -o server.o server.c
 
 runner.o: runner.c runner.h constants.h server.h
+	$(CC) $(CFLAGS) -c -o runner.o runner.c
 
 client.o: client.c network.h constants.h
+	$(CC) $(CFLAGS) -c -o client.o client.c
 
 hash.o: hash.h hash.c
+	$(CC) $(CFLAGS) -c -o hash.o hash.c
 
 hash_test.o: hash_test.c hash.h
+	$(CC) $(CFLAGS) -c -o hash_test.o hash_test.c
 
 conflicting_writes.o: conflicting_writes.c network.c constants.h network.h
+	$(CC) $(CFLAGS) -c -o conflicting_writes.o conflicting_writes.c
 
 clean:
 	rm *.o
 	rm server
 	rm client
 	rm hash_test
-	rm -r jobs
+	rm conflicting_writes
+	-rm -r jobs


### PR DESCRIPTION
gcc -g -lpthread -o server network.o server.o runner.o hash.o
/usr/bin/ld: server.o: in function `main':
/server.c:119: undefined reference to `pthread_create'
/usr/bin/ld: /server.c:122: undefined reference to `pthread_create'
/usr/bin/ld: /server.c:123: undefined reference to `pthread_join'
/usr/bin/ld: server.o: in function `finish':
/server.c:208: undefined reference to `pthread_kill'
/usr/bin/ld: server.o: in function `listener_set_up':
/server.c:497: undefined reference to `pthread_create'
/usr/bin/ld: server.o: in function `listen_for_connection':
/server.c:506: undefined reference to `pthread_create'
collect2: error: ld returned 1 exit status
make: *** [Makefile:9: server] Error 1