### PR TITLE
Update network.c

### DIFF
--- a/network.c
+++ b/network.c
@@ -8,6 +8,8 @@
 #include <errno.h>
 #include "constants.h"
 #include "network.h"
+#include <arpa/inet.h>
+
 
 int build_address(char *hostname, int port, struct sockaddr_in *inet_address) {
   struct hostent *host_entries;


### PR DESCRIPTION
Error:
network.c: In function ‘get_ip’:
network.c:101:9: warning: implicit declaration of function ‘inet_ntop’ [-Wimplicit-function-declaration]
  101 |     if(!inet_ntop(AF_INET, &(their_address.sin_addr), buffer, INET_ADDRSTRLEN))
      |         ^~~~~~~~~

Fix: add include file in network.c

#include <arpa/inet.h>