### PR TITLE
Update rpc.c

### DIFF
--- a/rpc.c
+++ b/rpc.c
@@ -1,3 +1,5 @@
+#include <pthread.h>
+
 void handle_rpc(int connection) {
   int rpc;
   char host[INET_ADDRSTRLEN];


### PR DESCRIPTION
Error:
rpc.c: In function ‘rpc_transfer_job’:
rpc.c:120:5: warning: implicit declaration of function ‘replicate_job’; did you mean ‘replicate_my_jobs’? [-Wimplicit-function-declaration]
  120 |     replicate_job(incoming);
      |     ^~~~~~~~~~~~~
      |     replicate_my_jobs


Fix: add int replicate_job(job *to_send); to server.h