### PR TITLE
Update server.h

### DIFF
--- a/server.h
+++ b/server.h
@@ -83,3 +83,9 @@ host_list *new_host_list_by_node(host_list_node *node);
 void notify_others_of_failure(host_port *failed_host);
 void inform_of_failure(int connection, host_port *failed_host);
 void update_q_host_failed ();
+
+
+int replicate_job(job *to_send);
+int send_meta_data(job *ajob);
+int remove_job(job_list_node *item, queue *list);
+int request_add_lock(int connection);


### PR DESCRIPTION
Error:
rpc.c: In function ‘rpc_transfer_job’:
rpc.c:120:5: warning: implicit declaration of function ‘replicate_job’; did you mean ‘replicate_my_jobs’? [-Wimplicit-function-declaration]
  120 |     replicate_job(incoming);
      |     ^~~~~~~~~~~~~
      |     replicate_my_jobs


Fix: add int replicate_job(job *to_send); to server.h