### PR TITLE
Update runner.c

### DIFF
--- a/runner.c
+++ b/runner.c
@@ -7,6 +7,7 @@
 #include <pthread.h>
 #include <time.h>
 #include "constants.h"
+#include <sys/wait.h>
 #include "server.h"
 #include "runner.h"
 


### PR DESCRIPTION
Error:
runner.c: In function ‘run_a_job’:
runner.c:71:5: warning: implicit declaration of function ‘waitpid’ [-Wimplicit-function-declaration]
   71 |     waitpid(forkint, &err, 0);
      |     ^~~~~~~
Fix: add #include <sys/wait.h> to runner.h or runner.c